### PR TITLE
Made corrections to Makefile and README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CFLAGS= -ggdb
 CXXFLAGS= -ggdb
 #CXXFLAGS= -ggdb -O2 
 #CXXFLAGS= -O2
-LFLAGS= -lfreeimageplus
+LFLAGS= -lfreeimageplus -lfreeimage
 
 CC=g++ 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 1. install dependencies 
 
-    $ sudo apt-get install libfreeimage-dev libjpeg8-dev
+    $ sudo apt-get install libfreeimage-dev libfreeimageplus-dev libjpeg8-dev
 
 ## 2. compile
 


### PR DESCRIPTION
The Makefile did not include links to libfreeimage, and the README.md did not include dependency on libfreeimageplus-dev.  This commit made those additions to allow mosait to compile properly.